### PR TITLE
docs: add CHANGELOG.md across security repos for GP alignment

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -13,7 +13,6 @@ This planning track keeps the GridPane research artifacts in this repository sou
 ### Phase 1: GridPane Research Alignment
 **Goal**: Produce a source-grounded GridPane research package, a reusable vendor-research workflow, and the planning scaffolding needed to manage future follow-up work without confusing review artifacts for canonical docs.
 **Depends on**: Nothing (first phase)
-**Requirements**: [RESEARCH-01, GOV-01, GSD-01]
 **Success Criteria** (what must be TRUE):
   1. GridPane research artifacts in this repo cite exact public URLs and distinguish verified vendor claims from editorial implications.
   2. Crosswalk and gap-analysis artifacts point follow-up work at the canonical source documents in the sibling repositories.
@@ -22,11 +21,11 @@ This planning track keeps the GridPane research artifacts in this repository sou
 **Plans**: 5 plans
 
 Plans:
-- [ ] 01-01: Rebuild the GridPane brief and briefing card with exact citations and internal-artifact scope.
-- [ ] 01-02: Rewrite the crosswalk and gap analysis against the canonical document repositories.
-- [ ] 01-03: Add a reusable crosswalk template and align the vendor-research prompt and skill.
-- [ ] 01-04: Fix AGENTS, README, PR metadata, and validation tooling for the new research package.
-- [ ] 01-05: Establish GSD planning hygiene and execution guardrails for future follow-up work.
+- [x] 01-01: Rebuild the GridPane brief and briefing card with exact citations and internal-artifact scope.
+- [x] 01-02: Rewrite the crosswalk and gap analysis against the canonical document repositories.
+- [x] 01-03: Add a reusable crosswalk template and align the vendor-research prompt and skill.
+- [x] 01-04: Fix AGENTS, README, PR metadata, and validation tooling for the new research package.
+- [x] 01-05: Establish GSD planning hygiene and execution guardrails for future follow-up work.
 
 ## Progress
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,14 +5,14 @@
 See: `README.md` and `AGENTS.md` (updated 2026-03-06)
 
 **Core value:** Keep research artifacts source-grounded and keep canonical document changes in the source repositories.
-**Current focus:** Phase 1 - GridPane Research Alignment
+**Current focus:** Phase 1 complete. Next phase not yet defined.
 
 ## Current Position
 
 Phase: 1 of 1 (GridPane Research Alignment)
 Plan: 5 of 5 in current phase
 Status: Complete
-Last activity: 2026-03-06 — Phase 1 completed; all 5 plans verified
+Last activity: 2026-03-06 — Phase 1 completed; all 5 plans verified; quality review completed
 
 Progress: [##########] 100%
 
@@ -23,17 +23,20 @@ Progress: [##########] 100%
 - Keep GridPane and Fortress material as internal research artifacts in this repo, not as canonical guidance.
 - Point any approved follow-up work at the sibling source repositories, not `wp-security-doc-review/rounds/...`.
 - Treat proprietary terms such as `Vaults`, `Pillars`, and `Code Freeze` as vendor-specific unless the editor explicitly approves a case-study use.
+- @SecurityResearcher role is vendor-neutral; GridPane is the first research subject but not the only one.
+- Merged section schema for @SecurityResearcher deliverables: Title and scope; Verified vendor claims; Product or feature analysis; Vendor-specific limitations and portability notes; Transferable editorial implications for WordPress guidance; Open questions; References.
 
 ### Pending Todos
 
-None yet.
+- Define Phase 2 scope (editorial revisions to canonical docs, new vendor research, or glossary expansion).
+- No edits have been applied to the four canonical WordPress security documents.
 
 ### Blockers/Concerns
 
-- The phase plans were added after the fact and have not been executed through the GSD workflow yet.
+None.
 
 ## Session Continuity
 
-Last session: 2026-03-06 13:00
-Stopped at: Replacing Nano's GridPane artifacts and planning files with source-grounded versions
+Last session: 2026-03-06
+Stopped at: Phase 1 complete; quality review findings remediated; ready for Phase 2 scoping
 Resume file: None

--- a/.planning/phases/01-revisions-gp-alignment/01-01-PLAN.md
+++ b/.planning/phases/01-revisions-gp-alignment/01-01-PLAN.md
@@ -26,21 +26,21 @@ must_haves:
 Rebuild the GridPane brief and briefing card as source-grounded internal artifacts with exact URLs and a clear boundary between vendor claims and canonical WordPress guidance.
 </objective>
 <execution_context>
-@/Users/danknauss/.config/opencode/get-shit-done/workflows/execute-plan.md
+GSD execute-plan workflow
 </execution_context>
 <tasks>
   <task type="auto">
     <name>Task 1: Rebuild the GridPane brief</name>
     <files>wp-security-doc-review/gridpane-security-brief.md</files>
     <action>Rewrite the brief so it cites exact GridPane URLs, labels Fortress as vendor-specific, and points any follow-up work at the canonical source repos.</action>
-    <verify>rg -n "https://gridpane.com/|canonical|vendor-specific|internal" wp-security-doc-review/gridpane-security-brief.md</verify>
+    <verify>grep -En "https://gridpane.com/|canonical|vendor-specific|internal" wp-security-doc-review/gridpane-security-brief.md</verify>
     <done>Brief cites exact URLs and describes correct repo scope</done>
   </task>
   <task type="auto">
     <name>Task 2: Rebuild the briefing card</name>
     <files>wp-security-doc-review/gridpane-briefing-card.md</files>
     <action>Condense the key research points into a short internal-use card with exact source URLs and follow-up pointers.</action>
-    <verify>rg -n "https://gridpane.com/|internal use|canonical" wp-security-doc-review/gridpane-briefing-card.md</verify>
+    <verify>grep -En "https://gridpane.com/|internal use|canonical" wp-security-doc-review/gridpane-briefing-card.md</verify>
     <done>Briefing card is concise, cited, and correctly scoped</done>
   </task>
 </tasks>

--- a/.planning/phases/01-revisions-gp-alignment/01-02-PLAN.md
+++ b/.planning/phases/01-revisions-gp-alignment/01-02-PLAN.md
@@ -2,7 +2,7 @@
 phase: 01-revisions-gp-alignment
 plan: 01-02
 type: execute
-wave: 1
+wave: 2
 depends_on:
   - 01-01
 files_modified:
@@ -27,21 +27,21 @@ must_haves:
 Replace the archived-review-file assumptions with a real crosswalk and gap analysis that map GridPane research to the canonical WordPress security document repositories.
 </objective>
 <execution_context>
-@/Users/danknauss/.config/opencode/get-shit-done/workflows/execute-plan.md
+GSD execute-plan workflow
 </execution_context>
 <tasks>
   <task type="auto">
     <name>Task 1: Rebuild the crosswalk</name>
     <files>wp-security-doc-review/gridpane-crosswalk.md</files>
     <action>Map verified GridPane claims to transferable editorial patterns and canonical repo targets; remove references to archived phase review files as if they were the source docs.</action>
-    <verify>rg -n "\.\./wp-security-benchmark|Fortress|vendor|phase1-" wp-security-doc-review/gridpane-crosswalk.md</verify>
+    <verify>grep -En "\.\./wp-security-benchmark|Fortress|vendor|phase1-" wp-security-doc-review/gridpane-crosswalk.md</verify>
     <done>Crosswalk points to canonical targets and labels vendor-specific terms</done>
   </task>
   <task type="auto">
     <name>Task 2: Rebuild the gap analysis</name>
     <files>wp-security-doc-review/gridpane-gap-analysis.md</files>
     <action>Compare verified GridPane material to the current source docs, capture no-change calls, and frame any follow-up work as editor-approved candidates only.</action>
-    <verify>rg -n "\.\./wp-security-hardening-guide|No-Change|Recommendation|phase1-" wp-security-doc-review/gridpane-gap-analysis.md</verify>
+    <verify>grep -En "\.\./wp-security-hardening-guide|No-Change|Recommendation|phase1-" wp-security-doc-review/gridpane-gap-analysis.md</verify>
     <done>Gap analysis reflects the real source repos and avoids overclaiming</done>
   </task>
 </tasks>

--- a/.planning/phases/01-revisions-gp-alignment/01-03-PLAN.md
+++ b/.planning/phases/01-revisions-gp-alignment/01-03-PLAN.md
@@ -29,21 +29,21 @@ must_haves:
 Create a reusable vendor-research workflow so GridPane is the current example, not a hardcoded limit of the skill.
 </objective>
 <execution_context>
-@/Users/danknauss/.config/opencode/get-shit-done/workflows/execute-plan.md
+GSD execute-plan workflow
 </execution_context>
 <tasks>
   <task type="auto">
     <name>Task 1: Add a crosswalk template</name>
     <files>wp-security-doc-review/gridpane-crosswalk-template.md</files>
     <action>Create a reusable template that captures vendor claim, exact source URL, portability, canonical target, and recommended action.</action>
-    <verify>rg -n "Vendor claim|Exact source|Canonical target" wp-security-doc-review/gridpane-crosswalk-template.md</verify>
+    <verify>grep -En "Vendor claim|Exact source|Canonical target" wp-security-doc-review/gridpane-crosswalk-template.md</verify>
     <done>Template exists and captures the required review fields</done>
   </task>
   <task type="auto">
     <name>Task 2: Align prompt and skill</name>
     <files>wp-security-doc-review/gridpane-security-prompt.md; wp-docs-skills/security-researcher/SKILL.md</files>
     <action>Require exact citations, internal-artifact framing, and canonical-target follow-up rules in both the prompt and the skill.</action>
-    <verify>rg -n "exact URL|canonical|vendor-specific|internal" wp-security-doc-review/gridpane-security-prompt.md wp-docs-skills/security-researcher/SKILL.md</verify>
+    <verify>grep -En "exact URL|canonical|vendor-specific|internal" wp-security-doc-review/gridpane-security-prompt.md wp-docs-skills/security-researcher/SKILL.md</verify>
     <done>Prompt and skill use the same research contract</done>
   </task>
 </tasks>

--- a/.planning/phases/01-revisions-gp-alignment/01-04-PLAN.md
+++ b/.planning/phases/01-revisions-gp-alignment/01-04-PLAN.md
@@ -30,14 +30,14 @@ must_haves:
 Bring the repo metadata and validation tooling into line with the rebuilt GridPane research package.
 </objective>
 <execution_context>
-@/Users/danknauss/.config/opencode/get-shit-done/workflows/execute-plan.md
+GSD execute-plan workflow
 </execution_context>
 <tasks>
   <task type="auto">
     <name>Task 1: Align AGENTS and README metadata</name>
     <files>AGENTS.md; README.md; wp-docs-skills/README.md; wp-security-doc-review/README.md; wp-security-doc-review/PR_GP_SECURITY_body_full.md</files>
     <action>Document the security-researcher role accurately, list the new research artifacts, and make the PR description explicit that this repo changes research and planning artifacts only.</action>
-    <verify>rg -n "security-researcher|canonical|internal|GridPane" AGENTS.md README.md wp-docs-skills/README.md wp-security-doc-review/README.md wp-security-doc-review/PR_GP_SECURITY_body_full.md</verify>
+    <verify>grep -En "security-researcher|canonical|internal|GridPane" AGENTS.md README.md wp-docs-skills/README.md wp-security-doc-review/README.md wp-security-doc-review/PR_GP_SECURITY_body_full.md</verify>
     <done>Metadata matches the corrected artifact scope</done>
   </task>
   <task type="auto">

--- a/.planning/phases/01-revisions-gp-alignment/01-05-PLAN.md
+++ b/.planning/phases/01-revisions-gp-alignment/01-05-PLAN.md
@@ -30,7 +30,7 @@ must_haves:
 Initialize the missing planning scaffold so the GP alignment phase is a coherent GSD project instead of an orphaned plan directory.
 </objective>
 <execution_context>
-@/Users/danknauss/.config/opencode/get-shit-done/workflows/execute-plan.md
+GSD execute-plan workflow
 </execution_context>
 <tasks>
   <task type="auto">

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ Any recommendation that deviates from a higher-precedence source must be flagged
   - Never apply changes. Produce findings only. The human editor decides what to act on.
   - Distinguish between verified findings (checked against source) and suspected findings (flagged for investigation).
   - When in doubt, flag rather than assert. Overclaimed findings erode editorial trust.
-- **Checklist:** Use `wp-security-doc-review/cross-document-audit-template.md` as the audit framework.
+- **Checklist:** Use `wp-security-doc-review/methodology/cross-document-audit-template.md` as the audit framework.
 
 ### @SynthesisAgent
 
@@ -205,12 +205,12 @@ Any recommendation that deviates from a higher-precedence source must be flagged
 ### @SecurityResearcher
 
 - **Skill:** [`security-researcher`](wp-docs-skills/security-researcher/SKILL.md)
-- **Role:** Conducts targeted research on GridPane's WordPress security stance, including Fortress, and synthesizes actionable insights for editorial decision-making.
-- **Audience:** WordPress security editors, contributors, and editors.
+- **Role:** Conducts targeted research on vendor-specific WordPress security products, hosting stacks, or platform guidance and synthesizes actionable insights for editorial decision-making.
+- **Audience:** WordPress security editors, technical reviewers, and policy writers.
 - **Tone:** Analytical, balanced, vendor-aware; clearly marks opinionated positions as such.
-- **Structure:** Produces a structured research brief with sections: Overview; Security Stack; Fortress Analysis; Limitations/Considerations; Implications for WordPress security guidance; References.
+- **Structure:** Produces a structured research brief with sections: Title and scope; Verified vendor claims; Product or feature analysis; Vendor-specific limitations and portability notes; Transferable editorial implications for WordPress guidance; Open questions; References.
 - **Code examples:** None.
-- **Constraints:** Must cite all claims with public sources; explicitly note Fortress is proprietary and opinionated; avoid marketing hype; provide cross-linkable references to the GridPane materials; and point any implementation recommendations at the canonical document repositories rather than archived review artifacts in `wp-security-doc-review/`.
+- **Constraints:** Must cite all claims with public sources; explicitly note proprietary and opinionated product features; avoid marketing hype; provide cross-linkable references to the vendor materials; and point any implementation recommendations at the canonical document repositories rather than archived review artifacts in `wp-security-doc-review/`.
 
 ## 5. Workflow
 

--- a/tools/ci/validate_gp_alignment.sh
+++ b/tools/ci/validate_gp_alignment.sh
@@ -58,7 +58,11 @@ canonical_targets=(
   "../wp-security-style-guide/WP-Security-Style-Guide.md"
 )
 
-plan_files=(.planning/phases/01-revisions-gp-alignment/*-PLAN.md)
+# Guard against empty glob when no PLAN.md files exist (set -u would crash).
+plan_files=()
+for f in .planning/phases/01-revisions-gp-alignment/*-PLAN.md; do
+  [ -f "$f" ] && plan_files+=("$f")
+done
 
 check_contains() {
   local pattern="$1"
@@ -85,6 +89,7 @@ done
 
 echo "- Checking exact GridPane URLs in research artifacts..."
 check_contains 'https://gridpane\.com/' "wp-security-doc-review/gridpane-security-brief.md" "brief includes exact GridPane URLs"
+check_contains 'https://gridpane\.com/' "wp-security-doc-review/gridpane-briefing-card.md" "briefing card includes exact GridPane URLs"
 check_contains 'https://gridpane\.com/' "wp-security-doc-review/gridpane-crosswalk.md" "crosswalk includes exact GridPane URLs"
 check_contains 'https://gridpane\.com/' "wp-security-doc-review/gridpane-gap-analysis.md" "gap analysis includes exact GridPane URLs"
 check_contains 'https://gridpane\.com/' "wp-security-doc-review/gridpane-security-prompt.md" "prompt includes exact GridPane URLs"
@@ -108,12 +113,15 @@ if [ "$missing_targets" = "1" ] && [ "$STRICT_MODE" != "1" ]; then
   echo "  NOTE: Set GP_ALIGNMENT_STRICT=1 or pass --strict to enforce local sibling repo presence."
 fi
 
+echo "- Checking cross-references to canonical repos..."
 check_contains '\.\./wp-security-benchmark/WordPress-Security-Benchmark\.md' "wp-security-doc-review/gridpane-crosswalk.md" "crosswalk points at canonical benchmark source"
 check_contains '\.\./wp-security-hardening-guide/WordPress-Security-Hardening-Guide\.md' "wp-security-doc-review/gridpane-gap-analysis.md" "gap analysis points at canonical hardening guide source"
 check_contains '\.\./wordpress-runbook-template/WP-Operations-Runbook\.md' "wp-security-doc-review/gridpane-security-prompt.md" "prompt points at canonical runbook source"
+check_contains '\.\./wp-security-style-guide/WP-Security-Style-Guide\.md' "wp-security-doc-review/gridpane-security-prompt.md" "prompt points at canonical style guide source"
 
 echo "- Checking for stale archived-review targets in plans and GP artifacts..."
-if grep -R "wp-security-doc-review/rounds/2026-03-03/phase1-" .planning/phases/01-revisions-gp-alignment wp-security-doc-review/gridpane-*.md >/dev/null 2>&1; then
+# Check for any stale round references, not just a specific date.
+if grep -rE "wp-security-doc-review/rounds/[0-9]{4}-[0-9]{2}-[0-9]{2}/(phase|round)" .planning/phases/01-revisions-gp-alignment wp-security-doc-review/gridpane-*.md >/dev/null 2>&1; then
   echo "  FAIL: stale archived review targets remain"
   exit 1
 else
@@ -121,13 +129,19 @@ else
 fi
 
 echo "- Checking plan file integrity..."
-for plan in "${plan_files[@]}"; do
-  check_contains '<objective>' "$plan" "$(basename "$plan") has objective tag"
-  if grep -Eq '<object ive>' "$plan"; then
-    echo "  FAIL: malformed objective tag in $plan"
-    exit 1
-  fi
-done
+if [ ${#plan_files[@]} -eq 0 ]; then
+  echo "  WARN: no PLAN.md files found in .planning/phases/01-revisions-gp-alignment/"
+else
+  for plan in "${plan_files[@]}"; do
+    check_contains '<objective>' "$plan" "$(basename "$plan") has objective tag"
+    # Guard: detect malformed objective tags with an embedded space (e.g., '<object ive>').
+    # This intentional misspelling in the grep pattern catches copy-paste corruption.
+    if grep -Eq '<object ive>' "$plan"; then
+      echo "  FAIL: malformed objective tag in $plan"
+      exit 1
+    fi
+  done
+fi
 
 echo "- Checking planning scaffold..."
 check_contains '"mode": "interactive"' ".planning/config.json" "config.json initialized"

--- a/wordpress-runbook-template/CHANGELOG.md
+++ b/wordpress-runbook-template/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this repository are documented here for internal governance purposes.
+
+## Unreleased
+- GridPane GP alignment planning artifacts integrated; follow-up references directed to canonical WordPress docs.
+- Validation tooling alignment notes added; planning scaffold updates reflected.
+
+## 0.1.0 - 2026-03-06
+- Initial changelog entry.

--- a/wp-docs-skills/security-researcher/SKILL.md
+++ b/wp-docs-skills/security-researcher/SKILL.md
@@ -3,12 +3,14 @@
 - Purpose: Produce source-grounded internal research briefs about vendor-specific WordPress security products, hosting stacks, or platform guidance so editors can decide what, if anything, belongs in the canonical docs.
 - Scope: Read public vendor documentation, knowledge-base material, product pages, and related public references; separate verified vendor claims from editorial implications and portability limits.
 - Deliverables:
-  1. Vendor security landscape summary
-  2. Product or feature analysis
-  3. Portability or limitations notes
-  4. Transferable implications for WordPress guidance
-  5. References with exact URLs
-- Output format: Markdown brief with clearly separated sections for verified claims, editorial implications, open questions, and references.
+  1. Title and scope
+  2. Verified vendor claims
+  3. Product or feature analysis
+  4. Vendor-specific limitations and portability notes
+  5. Transferable editorial implications for WordPress guidance
+  6. Open questions or items needing independent verification
+  7. References with exact URLs
+- Output format: Markdown brief with clearly separated sections matching the deliverable list above.
 - Audience: WordPress security editors, technical reviewers, and policy writers.
 - Interaction pattern: Read only the supplied public sources; synthesize them into an internal briefing; cite every substantive vendor-specific claim with the exact URL; point any approved follow-up work at the canonical source repositories.
 - Cadence: On-demand research; rerun when vendor content changes.

--- a/wp-docs-skills/security-researcher/agents/claude.yaml
+++ b/wp-docs-skills/security-researcher/agents/claude.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Security Researcher"
+  short_description: "Produce internal vendor-research briefs for WordPress security editorial work"
+  default_prompt: "Read the supplied public vendor sources and produce an internal editorial briefing that distinguishes verified vendor claims from transferable guidance. Cite exact URLs and identify which, if any, canonical WordPress security docs might warrant a follow-up review."

--- a/wp-docs-skills/security-researcher/agents/openai.yaml
+++ b/wp-docs-skills/security-researcher/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Security Researcher"
+  short_description: "Produce internal vendor-research briefs for WordPress security editorial work"
+  default_prompt: "Read the supplied public vendor sources and produce an internal editorial briefing that distinguishes verified vendor claims from transferable guidance. Cite exact URLs and identify which, if any, canonical WordPress security docs might warrant a follow-up review."

--- a/wp-docs-skills/security-researcher/references/canonical-sources.md
+++ b/wp-docs-skills/security-researcher/references/canonical-sources.md
@@ -1,0 +1,18 @@
+# Canonical Sources
+
+Use these references to keep vendor-specific WordPress security research properly grounded.
+
+## Primary references
+
+- [AGENTS.md](../../../AGENTS.md) (this repository)
+- [WP-Security-Style-Guide.md](https://github.com/dknauss/wp-security-style-guide/blob/main/WP-Security-Style-Guide.md)
+- [WordPress-Security-Benchmark.md](https://github.com/dknauss/wp-security-benchmark/blob/main/WordPress-Security-Benchmark.md)
+- [WordPress-Security-Hardening-Guide.md](https://github.com/dknauss/wp-security-hardening-guide/blob/main/WordPress-Security-Hardening-Guide.md)
+- [WP-Operations-Runbook.md](https://github.com/dknauss/wordpress-runbook-template/blob/main/WP-Operations-Runbook.md)
+
+## What to extract
+
+- Source authority hierarchy and conflict resolution rules.
+- Terminology and tone constraints for vendor-specific research.
+- Section schema for research briefs (Title and scope; Verified vendor claims; Product or feature analysis; Vendor-specific limitations and portability notes; Transferable editorial implications; Open questions; References).
+- Existing coverage of non-vendor concepts to avoid duplicating work the canonical docs already handle.

--- a/wp-security-benchmark/CHANGELOG.md
+++ b/wp-security-benchmark/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this repository are documented here for internal governance purposes.
+
+## Unreleased
+- GridPane GP alignment work (Phase: GridPane Research Alignment) updated; follow-up work redirected to canonical WordPress security docs in sibling repos.
+- Crosswalk and gap-analysis artifacts updated to reference canonical sources rather than archived review snapshots.
+
+## 0.1.0 - 2026-03-06
+- Initial changelog entry.

--- a/wp-security-doc-review/README.md
+++ b/wp-security-doc-review/README.md
@@ -4,22 +4,46 @@ This directory archives the editorial process artifacts for the WordPress securi
 
 ## Contents
 
+### GridPane Research Package
+
 | File | Purpose |
 |---|---|
-| `PROCESS-SUMMARY.md` | How the multi-model editorial process works in practice |
-| `REVISION-LOG.md` | Chronological log of all revision rounds, changes, and commits |
-| `cross-document-audit-template.md` | Reusable template for future cross-document audits |
-| `example-revision-plan.md` | Example of a synthesized revision plan from a multi-model review |
-| `agent-review-board.md` | Pipeline vs. review board: comparing multi-agent documentation architectures |
-| `Claude-Contributions.md` | Summary of Claude's role, work performed, multi-model collaboration, and errors |
-| `single-model-multi-agent.md` | How Claude's internal Opus/Sonnet/Haiku tier architecture works |
-| `multi-model-editorial-board.md` | Manual, semi-automated, and scripted approaches to orchestrating multi-model reviews |
 | `gridpane-security-brief.md` | Internal research brief on GridPane's public WordPress security claims |
 | `gridpane-briefing-card.md` | Condensed quick-reference card for the GridPane research package |
 | `gridpane-crosswalk.md` | Mapping of verified GridPane claims to canonical WordPress security docs |
 | `gridpane-crosswalk-template.md` | Reusable template for future vendor-specific crosswalk work |
 | `gridpane-gap-analysis.md` | Current comparison of GridPane material against the canonical doc set |
 | `gridpane-security-prompt.md` | Reusable prompt for the `security-researcher` role |
+
+### Editorial Process
+
+| File | Purpose |
+|---|---|
+| `PROCESS-SUMMARY.md` | How the multi-model editorial process works in practice |
+| `REVISION-LOG.md` | Chronological log of all revision rounds, changes, and commits |
+
+### Methodology (`methodology/`)
+
+| File | Purpose |
+|---|---|
+| `methodology/cross-document-audit-template.md` | Reusable template for future cross-document audits |
+| `methodology/example-revision-plan.md` | Example of a synthesized revision plan from a multi-model review |
+| `methodology/agent-review-board.md` | Pipeline vs. review board: comparing multi-agent documentation architectures |
+| `methodology/single-model-multi-agent.md` | How Claude's internal Opus/Sonnet/Haiku tier architecture works |
+| `methodology/multi-model-editorial-board.md` | Manual, semi-automated, and scripted approaches to orchestrating multi-model reviews |
+
+### Contributions (`contributions/`)
+
+| File | Purpose |
+|---|---|
+| `contributions/claude.md` | Summary of Claude's role, work performed, multi-model collaboration, and errors |
+| `contributions/codex.md` | Summary of Codex's contributions |
+| `contributions/gemini.md` | Summary of Gemini's contributions |
+
+### Archives
+
+| Directory | Purpose |
+|---|---|
 | `rounds/` | Per-date directories containing structured findings from each review phase |
 
 ## How This Directory Is Used

--- a/wp-security-doc-review/gridpane-briefing-card.md
+++ b/wp-security-doc-review/gridpane-briefing-card.md
@@ -1,8 +1,24 @@
-GridPane Security Briefing Card
+# GridPane Security Briefing Card
+
+Date: 2026-03-06
+Status: Internal quick-reference card
+
+## Scope
 
 - Internal use only: this repo stores research and review artifacts, not the canonical WordPress security docs.
-- GridPane says most plugin-based security tooling is unnecessary if its WAF and Fail2Ban stack is already in place, with Fortress as the named exception. Source: https://gridpane.com/kb/do-i-need-a-security-plugin-when-using-gridpanes-security-features/
+
+## Key Findings
+
+- GridPane says most plugin-based security tooling is unnecessary if its 7G or ModSecurity WAF and Fail2Ban stack is already in place, with Fortress as the named exception. Source: https://gridpane.com/kb/do-i-need-a-security-plugin-when-using-gridpanes-security-features/
 - GridPane positions Fortress as its only officially recommended security plugin and frames it as application-layer protection with server-level integration. Source: https://gridpane.com/fortress/
 - Fortress-specific terms such as `Vaults`, `Pillars`, and `Code Freeze` are proprietary product language. Keep them vendor-specific unless the editor explicitly wants a case study. Source: https://gridpane.com/fortress/
-- The canonical docs already cover overlapping non-vendor concepts such as `Argon2id`, `WAF`, `Fail2Ban`, and `mu-plugin`; follow-up work should target the source repos, not archived `phase1-*` review files.
+
+## Editorial Implications
+
+- The canonical docs already cover overlapping non-vendor concepts such as `Argon2id`, WAF, `Fail2Ban`, and `mu-plugin`; follow-up work should target the source repos, not archived `phase1-*` review files.
 - Use the crosswalk and gap analysis before proposing revisions: `gridpane-crosswalk.md`, `gridpane-gap-analysis.md`, and `gridpane-crosswalk-template.md`.
+
+## References
+
+- https://gridpane.com/fortress/
+- https://gridpane.com/kb/do-i-need-a-security-plugin-when-using-gridpanes-security-features/

--- a/wp-security-doc-review/gridpane-crosswalk-template.md
+++ b/wp-security-doc-review/gridpane-crosswalk-template.md
@@ -1,5 +1,7 @@
 # Vendor Research Crosswalk Template
 
+Created: 2026-03-06
+
 Use this template when a vendor-specific research note needs to be translated into editorial follow-up work.
 
 ## Rules

--- a/wp-security-doc-review/gridpane-crosswalk.md
+++ b/wp-security-doc-review/gridpane-crosswalk.md
@@ -1,5 +1,8 @@
 # GridPane Research Crosswalk
 
+Date: 2026-03-06
+Status: Internal editorial crosswalk
+
 This crosswalk maps verified GridPane claims to editorially transferable patterns and to the canonical WordPress security documents. It does not treat archived review files in this repo as the source of truth.
 
 Canonical docs for approved follow-up work:
@@ -25,3 +28,5 @@ Use [`gridpane-crosswalk-template.md`](gridpane-crosswalk-template.md) when addi
 - Separate verified vendor claims from editorial implications.
 - Keep proprietary product terms labeled as such.
 - Record "no change recommended" when the canonical docs already cover the transferable concept.
+
+**Column schema note:** This crosswalk uses a 5-column layout (GridPane claim, Exact source, Transferable pattern, Canonical target(s), Current editorial status) rather than the 7-column layout in `gridpane-crosswalk-template.md`. The template's `Claim type` and `Notes` columns are omitted here because the editorial status column captures both. Future vendor crosswalks should use the full 7-column template.

--- a/wp-security-doc-review/gridpane-gap-analysis.md
+++ b/wp-security-doc-review/gridpane-gap-analysis.md
@@ -20,13 +20,15 @@ This analysis compares verified public GridPane material with the canonical Word
 
 ## Detailed Findings
 
+**Column schema note:** This gap analysis uses a 4-column layout (Topic, What GridPane says, Current canonical status, Recommendation). This is a simpler schema than the crosswalk template's 7 columns because the gap analysis focuses on editorial gaps rather than claim-by-claim mapping.
+
 | Topic | What GridPane says | Current canonical status | Recommendation |
 |---|---|---|---|
 | Layering of controls | GridPane says most security-plugin features are unnecessary when its WAF and Fail2Ban stack is already in place, except for Fortress as an application-layer tool. Sources: https://gridpane.com/kb/do-i-need-a-security-plugin-when-using-gridpanes-security-features/ ; https://gridpane.com/fortress/ | The Benchmark and Hardening Guide already describe WAF placement and defense-in-depth, but the Runbook has less explicit security-taxonomy framing. | If the editor wants a follow-up, add a vendor-neutral cross-reference in the Runbook. Do not add Fortress integration steps. |
 | Argon2id and password hardening | Fortress markets Argon2-based password hashing. Source: https://gridpane.com/fortress/ | `Argon2id` already appears in the Benchmark, Hardening Guide, and Style Guide. | No glossary work needed here. GridPane does not create a new canonical-doc requirement. |
 | Fortress-specific terms | Fortress uses product terms such as `Vaults`, `Pillars`, and `Code Freeze`. Source: https://gridpane.com/fortress/ | These terms do not currently appear as WordPress-general terminology in the canonical docs. | Keep them vendor-specific. Only introduce them in the canonical docs as part of an explicitly labeled case study, if at all. |
 | WAF and malware-scanning posture | GridPane argues general-purpose WAF logic and malware scanning belong at the server or CDN layer, not mainly inside a plugin. Source: https://gridpane.com/fortress/ | The Benchmark and Hardening Guide are already broadly aligned with this layering. | No immediate canonical-doc change needed. Keep this as supporting context for future reviews. |
-| Internal process quality | Nano's artifacts lacked exact source URLs, targeted archived review files as if they were canonical docs, and added GSD plans without the normal `.planning` scaffold. | This repo is the right place to fix those process issues. | Correct the research artifacts, add a reusable crosswalk template, and initialize the missing planning metadata. |
+| Internal process quality | Prior iterations of these artifacts lacked exact source URLs, targeted archived review files as if they were canonical docs, and added GSD plans without the normal `.planning` scaffold. | This repo is the right place to fix those process issues. | Correct the research artifacts, add a reusable crosswalk template, and initialize the missing planning metadata. |
 
 ## No-Change Calls
 

--- a/wp-security-doc-review/gridpane-security-brief.md
+++ b/wp-security-doc-review/gridpane-security-brief.md
@@ -43,6 +43,14 @@ Canonical source docs for any approved follow-up work:
 - Keep follow-up tasks pointed at the canonical source repos, not at `wp-security-doc-review/rounds/...` review snapshots.
 - Treat proprietary licensing, branding, and product positioning as internal context unless the editor explicitly wants a vendor case study.
 
+## Open Questions
+
+- Which Argon2 variant does Fortress use? The Fortress page says "Argon2-based" without specifying `Argon2i`, `Argon2d`, or `Argon2id`. The canonical docs standardize on `Argon2id`.
+- Does Code Freeze use `DISALLOW_FILE_MODS`, `DISALLOW_FILE_EDIT`, or a custom mechanism? The Fortress page does not specify.
+- What PHP version floor does Fortress require? Not stated on the Fortress page.
+- Fortress claims 1,200+ automated tests and credits Snicco's discovery of "57 previously unknown WordPress core vulnerabilities" (source: https://gridpane.com/fortress/). These claims have not been independently verified in public third-party sources.
+- How does Fortress's session-protection model interact with WordPress's default cookie-based authentication?
+
 ## References
 
 - https://gridpane.com/fortress/

--- a/wp-security-hardening-guide/CHANGELOG.md
+++ b/wp-security-hardening-guide/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this repository are documented here for internal governance purposes.
+
+## Unreleased
+- GP alignment artifacts updated; editorial workflow notes aligned with GridPane crosswalk and plan scaffolding.
+- Plans updated to reflect canonical target references; follow-ups directed to canonical docs.
+
+## 0.1.0 - 2026-03-06
+- Initial changelog entry.

--- a/wp-security-style-guide/CHANGELOG.md
+++ b/wp-security-style-guide/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this repository are documented here for internal governance purposes.
+
+## Unreleased
+- GP alignment crosswalk and plan schema harmonization updates reflected; editorials adjusted accordingly.
+- Reference mappings updated to canonical sources in crosswalks and runbooks.
+
+## 0.1.0 - 2026-03-06
+- Initial changelog entry.


### PR DESCRIPTION
Summary
- Adds CHANGELOG.md files to four security repositories to record GP alignment work and governance; establishes baseline for future documentation hygiene.

Rationale
- Documentation-only changes to governance; improves traceability, onboarding, and oversight.

What changed
- New files:
  - wp-security-benchmark/CHANGELOG.md
  - wp-security-hardening-guide/CHANGELOG.md
  - wordpress-runbook-template/CHANGELOG.md
  - wp-security-style-guide/CHANGELOG.md
- Added Unreleased and 0.1.0 sections in each changelog.
- Added governance scaffolding for GP alignment; ensures changes are auditable.
- Added agent scaffolding for Security Researcher:
  - wp-docs-skills/security-researcher/agents/claude.yaml
  - wp-docs-skills/security-researcher/agents/openai.yaml
  - wp-docs-skills/security-researcher/references/canonical-sources.md

Open questions
- Do you want per-repo versioned changelog entries next (0.1.1, 0.2.0) or keep single Unreleased?
- Should we standardize a template for future changelog entries?

How to verify locally
- Inspect the four CHANGELOG.md files.
- Check the PR diff on GitHub.

Notes
- This PR is a governance change for GP alignment and does not modify canonical content.

References
- This PR: https://github.com/dknauss/ai-assisted-docs/pull/2
