### PR TITLE
Docs: fix preflight follow-up regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 Unreleased
+- Preflight follow-up: normalized a committed runbook review artifact to avoid machine-local paths, refreshed the synced Runbook counts in `docs/current-metrics.md`, and re-ran the editorial preflight from `main` to confirm the portability and cross-repo metrics checks pass.
 - Skill distribution hardening: added `tools/sync_wp_docs_skills.sh` to install full WordPress skill bundles plus their mirrored `scenarios/` tree into `~/.codex/` and `~/.agents/`, added `tools/ci/validate_skill_bundles.py` plus a new preflight integrity check, and refreshed this repo's cross-repo metrics table to current downstream values so preflight passes again.
 - Repo portfolio tracking: Removed the temporary `.tmp-docs-workflows/` scratch clones, added `wp-perfopt-guide` as an associated Performance series repo in project metadata, and clarified that the four-document security series remains the canonical scope for this AGENTS file and workflow summaries.
 - Repository structure: flattened the redundant nested `ai-assisted-docs/ai-assisted-docs/` checkout into a single repo root, renamed `wp-security-doc-review/` to `reviews/`, and moved repo-named tracking folders under `downstream-tracking/` to distinguish internal governance notes from the sibling canonical document repositories.

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -46,18 +46,18 @@ Each downstream repo maintains its own `docs/current-metrics.md` with verificati
 
 | Metric | Benchmark | Hardening Guide | Runbook | Style Guide |
 |---|---:|---:|---:|---:|
-| Document lines | 2,424 | 627 | 3,375 | 701 |
+| Document lines | 2,424 | 627 | 3,394 | 701 |
 | Major sections (H2) | 22 | 17 | 11 | 12 |
 | Security controls | 50 | — | — | — |
 | Glossary terms | — | — | — | 143 |
 | Code fences | 250 | 0 | 168 | 0 |
 | WP-CLI commands | 4 | 0 | 149 | 0 |
 | Destructive commands | — | — | 44 | — |
-| Inline WARNINGs | 0 | 0 | 16 | 0 |
+| Inline WARNINGs | 0 | 0 | 35 | 0 |
 | CUSTOMIZE placeholders | 2 | 0 | 196 | 0 |
 | Has CHANGELOG.md | Yes | Yes | Yes | Yes |
 | Has docs/current-metrics.md | Yes | Yes | Yes | Yes |
-| Last metrics verified | 2026-06-14 | 2026-06-14 | 2026-03-15 | 2026-06-14 |
+| Last metrics verified | 2026-06-14 | 2026-06-14 | 2026-06-14 | 2026-06-14 |
 
 ### Cross-Repo Verification
 

--- a/reviews/rounds/2026-06-14/runbook-skill-validation-older-vs-current.md
+++ b/reviews/rounds/2026-06-14/runbook-skill-validation-older-vs-current.md
@@ -17,23 +17,23 @@ to determine whether the skill usefully distinguishes legacy procedural weakness
 
 ### Skills tested
 
-- `/Users/danknauss/.codex/skills/wordpress-runbook-ops/SKILL.md`
-- `/Users/danknauss/.codex/skills/wordpress-security-doc-editor/SKILL.md`
+- `~/.codex/skills/wordpress-runbook-ops/SKILL.md`
+- `~/.codex/skills/wordpress-security-doc-editor/SKILL.md`
 
 ### Canonical/source references loaded
 
-- `/Users/danknauss/.codex/skills/wordpress-runbook-ops/references/canonical-sources.md`
-- `/Users/danknauss/.codex/skills/wordpress-security-doc-editor/references/canonical-sources.md`
-- `/Users/danknauss/.codex/scenarios/wordpress-runbook-ops/procedure-schema-completeness.md`
-- `/Users/danknauss/.codex/scenarios/wordpress-runbook-ops/command-validity.md`
-- `/Users/danknauss/.codex/scenarios/wordpress-security-doc-editor/cross-document-alignment.md`
+- `~/.codex/skills/wordpress-runbook-ops/references/canonical-sources.md`
+- `~/.codex/skills/wordpress-security-doc-editor/references/canonical-sources.md`
+- `~/.codex/scenarios/wordpress-runbook-ops/procedure-schema-completeness.md`
+- `~/.codex/scenarios/wordpress-runbook-ops/command-validity.md`
+- `~/.codex/scenarios/wordpress-security-doc-editor/cross-document-alignment.md`
 
 ### Runbook targets
 
 - **Older snapshot:** `/tmp/WP-Operations-Runbook-4a18785.md`
   - extracted from `wordpress-runbook-template` commit `4a18785`
   - line count: `3237`
-- **Current canonical runbook:** `/Users/danknauss/Developer/GitHub/wordpress-runbook-template/WP-Operations-Runbook.md`
+- **Current canonical runbook:** `../wordpress-runbook-template/WP-Operations-Runbook.md`
   - audited in the patched working tree on branch `docs/runbook-skill-alignment`
   - pre-patch `HEAD` at audit start: `46ec929` (`docs: add badges and AI disclosure`)
   - line count after patch: `3394`


### PR DESCRIPTION
## Summary
- normalize the committed runbook skill validation artifact so it no longer embeds machine-local paths
- refresh the synced Runbook counts in `docs/current-metrics.md` after the merged runbook edits
- record the follow-up in `CHANGELOG.md`

## Why
After merging the skill-install hardening PR, a fresh preflight run from `main` exposed two follow-up regressions:
- a committed review artifact still contained `/Users/...` paths that the new portability check correctly rejects
- the cross-repo metrics table still had stale Runbook counts after the latest canonical runbook merge

This PR brings `main` back into compliance with the new checks it now enforces.

## Validation
- `bash tools/sync_wp_docs_skills.sh`
- `bash tools/ci/review_preflight.sh`
