### PR TITLE
Docs: refresh planning state and cross-repo metrics

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,55 +2,44 @@
 
 ## Project Reference
 
-See: `README.md` and `AGENTS.md` (updated 2026-03-06)
-Current metrics: `docs/current-metrics.md` (in sibling canonical repos)
+See: `docs/current-metrics.md` for canonical series facts and `README.md` for the current editorial/process surface.
 
-**Core value:** Keep research artifacts source-grounded and keep canonical document changes in the source repositories.
-**Current focus:** Backlog — focused runbook review and WordPress 7.0 readiness ahead of the April 9, 2026 release date.
+**Core value:** Keep the WordPress security document series accurate, cross-repo consistent, and operationally maintainable.
+**Current focus:** Maintenance backlog after the WordPress 7.0 alignment round, skill-install hardening, and review-preflight repairs.
 
 ## Current Position
 
 Phase: All planned phases complete (2 of 2)
-Status: Backlog
-Last activity: 2026-03-15 — Phase 2 closed; synthesis corrections applied to all four canonical repos; backlog updated with new high-priority items
-
-Progress: [████████] 12/12 plans complete (100%)
+Status: Maintenance backlog
+Last activity: 2026-06-17 — merged skill-install hardening and preflight follow-up fixes; sibling canonical repos are now back in sync with the local editorial tooling.
 
 ## Accumulated Context
 
-### Phase 1 Summary (Complete)
+- `docs/current-metrics.md` is the source of truth for the security-series repo count and cross-repo metrics snapshot.
+- The WordPress 7.0 post-release alignment work is complete; any new work should be framed as backlog, maintenance, or a fresh approved phase.
+- Skill bundles now sync through `tools/sync_wp_docs_skills.sh`, and `tools/ci/review_preflight.sh` enforces portability and cross-repo metrics checks.
 
-- Initial GridPane research covered only 2 URLs (Fortress page, security plugin KB)
-- Gap identified: Security KB was not comprehensively reviewed
-- Decision: Phase 2 must expand GridPane research to all 32 security articles
+## Historical Phase Summary
+
+### Phase 1 Summary (Complete)
+- Built the initial research and editorial workflow foundation.
+- Established the cross-document review archive and methodology.
 
 ### Phase 2 Summary (Complete)
+- Consolidated the canonical publication pipeline and output polish.
+- Landed reusable workflow hardening, artifact validation, and downstream repo normalization.
 
-1. **Comprehensive GridPane Security Research** — All 32 security KB articles reviewed; brief and crosswalk updated with 36 verified claims.
-2. **New Vendor Research** — WordPress VIP (43 verified claims) and Patchstack (23 verified claims) researched in 7-section brief format.
-3. **Multi-Model Editorial Review** — Gemini 3 Pro, GPT-5.4-Codex, Claude Opus 4.6 reviewed all 4 canonical docs. 16 findings merged; all applied or dispositioned.
-4. **Canonical Repo Audit** — All March 2026 findings verified and applied.
-5. **Glossary Maintenance** — All 7 terms already present; ordering verified correct.
-6. **Synthesis Corrections Applied** — Codex applied all 16 fixes across the 4 canonical repos on 2026-03-15. Commits pushed and metrics refreshed.
+## Pending Backlog
 
-### Decisions
+- Open new phases only for newly approved scoped work; do not treat pre-7.0 readiness notes as active work.
+- Continue periodic cross-repo audits and post-release maintenance as needed.
 
-- Keep GridPane, VIP, Patchstack material as internal research artifacts in this repo, not as canonical guidance.
-- Point any approved follow-up work at the sibling source repositories, not `reviews/rounds/...`.
-- Treat proprietary product terms as vendor-specific unless the editor explicitly approves a case-study use.
-- @SecurityResearcher role is vendor-neutral; vendors include hosts (GridPane), enterprise platforms (VIP), and security products (Patchstack).
-- Research format: 7-section brief (Title/scope, Verified claims, Feature analysis, Limitations, Editorial implications, Open questions, References).
-
-### Pending Todos
-
-None — all Phase 1 and Phase 2 plans complete. Next work draws from the ROADMAP.md backlog.
-
-### Blockers/Concerns
+## Blockers
 
 None.
 
-## Session Continuity
+## Session
 
-Last session: 2026-03-15
-Stopped at: All housekeeping complete; backlog updated; ready for next work item
-Resume file: `.planning/ROADMAP.md`
+Last Date: 2026-06-17 MDT
+Stopped At: Maintenance state refreshed after post-release workflow and skill-install fixes
+Resume File: None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 Unreleased
+- Planning hygiene: refreshed `.planning/STATE.md` so the current-focus summary no longer points to pre-release WordPress 7.0 work that is already complete.
 - Preflight follow-up: normalized a committed runbook review artifact to avoid machine-local paths, refreshed the synced Runbook counts in `docs/current-metrics.md`, and re-ran the editorial preflight from `main` to confirm the portability and cross-repo metrics checks pass.
 - Skill distribution hardening: added `tools/sync_wp_docs_skills.sh` to install full WordPress skill bundles plus their mirrored `scenarios/` tree into `~/.codex/` and `~/.agents/`, added `tools/ci/validate_skill_bundles.py` plus a new preflight integrity check, and refreshed this repo's cross-repo metrics table to current downstream values so preflight passes again.
 - Repo portfolio tracking: Removed the temporary `.tmp-docs-workflows/` scratch clones, added `wp-perfopt-guide` as an associated Performance series repo in project metadata, and clarified that the four-document security series remains the canonical scope for this AGENTS file and workflow summaries.

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -46,7 +46,7 @@ Each downstream repo maintains its own `docs/current-metrics.md` with verificati
 
 | Metric | Benchmark | Hardening Guide | Runbook | Style Guide |
 |---|---:|---:|---:|---:|
-| Document lines | 2,424 | 627 | 3,394 | 701 |
+| Document lines | 2,424 | 627 | 3,394 | 732 |
 | Major sections (H2) | 22 | 17 | 11 | 12 |
 | Security controls | 50 | — | — | — |
 | Glossary terms | — | — | — | 143 |
@@ -57,7 +57,7 @@ Each downstream repo maintains its own `docs/current-metrics.md` with verificati
 | CUSTOMIZE placeholders | 2 | 0 | 196 | 0 |
 | Has CHANGELOG.md | Yes | Yes | Yes | Yes |
 | Has docs/current-metrics.md | Yes | Yes | Yes | Yes |
-| Last metrics verified | 2026-06-14 | 2026-06-14 | 2026-06-14 | 2026-06-14 |
+| Last metrics verified | 2026-06-14 | 2026-06-14 | 2026-06-14 | 2026-06-16 |
 
 ### Cross-Repo Verification
 


### PR DESCRIPTION
Lands the docs CI refactor (removes the setup-docs-toolchain composite action in favor of inline steps in reusable-generate-docs.yml) plus a planning-state refresh (.planning/STATE.md, docs/current-metrics.md) and a CHANGELOG entry.

Merges cleanly into main. Part of the ai-assisted-docs branch cleanup.