### PR TITLE
Docs: editorial methodology, performance-series tracking & CI refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Agent configuration for AI-assisted editorial work on the four-document WordPres
 - **Goal:** Maintain technical accuracy, cross-document consistency, and stylistic coherence across all four documents while respecting each document's audience and purpose.
 - **Source of truth for style:** [WP-Security-Style-Guide.md](https://github.com/dknauss/wp-security-style-guide)
 - **Source of truth for counts:** `docs/current-metrics.md` — document set facts, downstream repo count, phase status. Check before writing any volatile count.
+- **Scope note:** This AGENTS file governs the four-document WordPress security series. Associated repos or series tracked in `docs/current-metrics.md` (for example, the Performance series in `wp-perfopt-guide`) do not automatically inherit these agent roles unless explicitly added.
 
 | Document | Repository | Audience | Purpose |
 |---|---|---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 Unreleased
+- Repo portfolio tracking: Removed the temporary `.tmp-docs-workflows/` scratch clones, added `wp-perfopt-guide` as an associated Performance series repo in project metadata, and clarified that the four-document security series remains the canonical scope for this AGENTS file and workflow summaries.
 - Repository structure: flattened the redundant nested `ai-assisted-docs/ai-assisted-docs/` checkout into a single repo root, renamed `wp-security-doc-review/` to `reviews/`, and moved repo-named tracking folders under `downstream-tracking/` to distinguish internal governance notes from the sibling canonical document repositories.
 - Canonical docs: Cited WordPress VIP step-up authentication as an example platform implementation of action-gated reauthentication in Benchmark §5.5 and Hardening Guide §8.2, completing the medium-priority backlog item.
 - Editorial review: Closed the focused 2026-03-15 Runbook round after applying all 12 synthesized findings in `wordpress-runbook-template` commit `a323448`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 Unreleased
+- Skill distribution hardening: added `tools/sync_wp_docs_skills.sh` to install full WordPress skill bundles plus their mirrored `scenarios/` tree into `~/.codex/` and `~/.agents/`, added `tools/ci/validate_skill_bundles.py` plus a new preflight integrity check, and refreshed this repo's cross-repo metrics table to current downstream values so preflight passes again.
 - Repo portfolio tracking: Removed the temporary `.tmp-docs-workflows/` scratch clones, added `wp-perfopt-guide` as an associated Performance series repo in project metadata, and clarified that the four-document security series remains the canonical scope for this AGENTS file and workflow summaries.
 - Repository structure: flattened the redundant nested `ai-assisted-docs/ai-assisted-docs/` checkout into a single repo root, renamed `wp-security-doc-review/` to `reviews/`, and moved repo-named tracking folders under `downstream-tracking/` to distinguish internal governance notes from the sibling canonical document repositories.
 - Canonical docs: Cited WordPress VIP step-up authentication as an example platform implementation of action-gated reauthentication in Benchmark §5.5 and Hardening Guide §8.2, completing the medium-priority backlog item.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ If a directory inside this repo is named after one of the downstream document re
 
 This repository includes the editorial agent skills used in the WordPress document workflow. These live in [`wp-docs-skills/`](wp-docs-skills/) and serve as both process transparency and reusable machine-readable guidance for AI-assisted edits. See the [skills index](wp-docs-skills/README.md) for usage instructions.
 
+To install or refresh the full local skill bundles — including `agents/`, `references/`, and the mirrored `scenarios/` tree those skills reference — into `~/.codex/` and `~/.agents/`, run:
+
+```bash
+bash tools/sync_wp_docs_skills.sh
+```
+
 ## Behavioral Scenarios
 
 The [`scenarios/`](scenarios/) directory contains Given/When/Then behavioral specifications for each skill. These turn the acceptance criteria in [AGENTS.md](AGENTS.md) section 6 and each skill's `SKILL.md` done criteria into testable expectations with concrete pass/fail examples. During editorial review, check AI-generated output against the applicable scenarios before accepting it. See the [scenarios index](scenarios/README.md) for format, usage, and [test run results](scenarios/README.md#test-runs).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a methodology, process documentation, and working scrip
 
 For CI status on the shared Pandoc generation pipeline, treat **Validate Reusable Docs Workflow** as the health signal for the reusable docs workflow. The reusable `workflow_call` entrypoint is designed to be called from other repositories, so its standalone badge/run history can reflect older downstream failures even when this repository's validation workflow is green.
 
-As a working system, `ai-assisted-docs` curates and maintains a series of technical documents about WordPress security contained in four separate repositories, ensuring they remain living documents aligned with current code and industry standards. 
+As a working system, `ai-assisted-docs` curates and maintains a series of technical documents about WordPress security contained in four separate repositories, ensuring they remain living documents aligned with current code and industry standards. It can also track adjacent associated documentation repos when they share tooling or editorial process, without collapsing them into the four-document security series. 
 
 **End-to-end transparency is a key feature.** Readers of the resulting documents should be able to understand how AI was involved, what guardrails were in place, what authority hierarchies were followed, and where human editorial judgment was applied.
 
@@ -21,7 +21,13 @@ As a working system, `ai-assisted-docs` curates and maintains a series of techni
 
 ## Repository Layout
 
-The four canonical documents do not live in this repository. They live in the four sibling repositories linked above.
+The four canonical security documents do not live in this repository. They live in the four sibling repositories linked above.
+
+### Associated Technical Series
+
+| Series | Repository | Status | Notes |
+|---|---|---|---|
+| Performance series | `wp-perfopt-guide` | Local onboarding in progress | Separate from the four-document security series; may reuse process, validation, and publication patterns. |
 
 This repository contains the shared editorial system around them:
 
@@ -60,7 +66,7 @@ Each downstream document repo maintains two tracking files:
 - **`docs/current-metrics.md`** — canonical architectural counts (sections, controls, glossary terms, WP-CLI commands, code fences, etc.) with runnable verification commands. Updated after every structural edit.
 - **`CHANGELOG.md`** — revision history. Updated after every substantive change.
 
-This repo's [`docs/current-metrics.md`](docs/current-metrics.md) aggregates key counts across all four downstream repos and tracks editorial project-level facts (scenario files, phases, research subjects).
+This repo's [`docs/current-metrics.md`](docs/current-metrics.md) aggregates key counts across the four downstream security repos and tracks editorial project-level facts (scenario files, phases, research subjects, and associated series).
 
 The [AGENTS.md](AGENTS.md) workflow (sections 5.1 and 5.2) includes metrics verification and changelog update steps at the end of every drafting and revision round.
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -2,22 +2,23 @@
 
 This file is the single source of truth for current project counts.
 
-Last verified: 2026-03-21
+Last verified: 2026-06-14
 Verification environment: sibling repo checkouts beside this repository root (for example, `../wp-security-benchmark`)
 
 ## Document Series Facts
 
 | Fact | Value | Verification | Last changed |
 |---|---:|---|---|
-| Canonical documents | 4 | See table below | v1.0 |
-| Downstream repos | 4 | `ls -d wp-security-* wordpress-runbook-*` (submodules/siblings) | v1.0 |
+| Canonical security documents | 4 | See canonical security table below | v1.0 |
+| Downstream security repos | 4 | `ls -d wp-security-* wordpress-runbook-*` (submodules/siblings) | v1.0 |
+| Associated non-security series | 1 | Performance series in sibling repo `wp-perfopt-guide` | 2026-06-14 |
 | Research subjects | 1 | GridPane (first; vendor-neutral framework designed for more) | Phase 1 |
 | Planning phases | 2 | `ls .planning/phases/` | Phase 2 defined |
 | Behavioral scenario files | 14 | `find scenarios -name '*.md' ! -name 'README.md' | wc -l` | v1.1 |
 | Cross-repo metrics sync check script | 1 | `bash tools/ci/validate_cross_repo_metrics.sh` | Phase 2 |
 | Shared build outputs | 4 formats | Markdown source, DOCX, EPUB, PDF per document | Phase 2 scope |
 
-### Canonical Document Set
+### Canonical Security Document Set
 
 | Document | Repository | Audience |
 |---|---|---|
@@ -25,6 +26,12 @@ Verification environment: sibling repo checkouts beside this repository root (fo
 | Hardening Guide | `wp-security-hardening-guide` | Architects, developers |
 | Operations Runbook | `wordpress-runbook-template` | SREs, operators |
 | Style Guide | `wp-security-style-guide` | Writers, communicators |
+
+### Associated Technical Series
+
+| Series | Repository | Scope | Status |
+|---|---|---|---|
+| Performance series | `wp-perfopt-guide` | Separate multi-document performance docs repo that may reuse this editorial and publication process | Local onboarding in progress |
 
 ### Files that reference these counts
 
@@ -70,7 +77,7 @@ After a cross-document revision round, run the verification script in each modif
 
 ## Update Procedure
 
-1. Update this file when adding a new canonical document, downstream repo, or research subject.
+1. Update this file when adding a new canonical security document, downstream security repo, associated series, or research subject.
 2. After a revision round, update the Cross-Repo Document Metrics table with current values from each repo's `docs/current-metrics.md`.
 3. Cross-reference `.planning/STATE.md` for phase status.
 4. Keep `AGENTS.md` and `README.md` aligned with facts in this file.

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -46,10 +46,10 @@ Each downstream repo maintains its own `docs/current-metrics.md` with verificati
 
 | Metric | Benchmark | Hardening Guide | Runbook | Style Guide |
 |---|---:|---:|---:|---:|
-| Document lines | 2,423 | 621 | 3,375 | 693 |
+| Document lines | 2,424 | 627 | 3,375 | 701 |
 | Major sections (H2) | 22 | 17 | 11 | 12 |
 | Security controls | 50 | — | — | — |
-| Glossary terms | — | — | — | 139 |
+| Glossary terms | — | — | — | 143 |
 | Code fences | 250 | 0 | 168 | 0 |
 | WP-CLI commands | 4 | 0 | 149 | 0 |
 | Destructive commands | — | — | 44 | — |
@@ -57,14 +57,14 @@ Each downstream repo maintains its own `docs/current-metrics.md` with verificati
 | CUSTOMIZE placeholders | 2 | 0 | 196 | 0 |
 | Has CHANGELOG.md | Yes | Yes | Yes | Yes |
 | Has docs/current-metrics.md | Yes | Yes | Yes | Yes |
-| Last metrics verified | 2026-03-21 | 2026-03-21 | 2026-03-21 | 2026-03-21 |
+| Last metrics verified | 2026-06-14 | 2026-06-14 | 2026-03-15 | 2026-06-14 |
 
 ### Cross-Repo Verification
 
 After a cross-document revision round, run the verification script in each modified repo's `docs/current-metrics.md` and update this table. Key cross-repo checks:
 
 - **Control classification alignment:** Same control has same L1/L2 in Benchmark and Hardening Guide.
-- **Terminology consistency:** Terms used in 2+ documents match the Style Guide glossary (139 terms).
+- **Terminology consistency:** Terms used in 2+ documents match the Style Guide glossary (143 terms).
 - **Version references:** "As of WordPress X.Y" and PHP version floors match across all four documents.
 - **Code fence integrity:** Opening/closing fence counts balance in Benchmark (250) and Runbook (168).
 

--- a/downstream-tracking/README.md
+++ b/downstream-tracking/README.md
@@ -1,13 +1,13 @@
 # Downstream Tracking
 
-This directory stores lightweight internal governance notes about the four sibling canonical document repositories:
+This directory stores lightweight internal governance notes about the four sibling canonical security document repositories:
 
 - `wordpress-runbook-template`
 - `wp-security-benchmark`
 - `wp-security-hardening-guide`
 - `wp-security-style-guide`
 
-These directories are not local mirrors of the canonical repositories and they are not a source of published document content.
+These directories are not local mirrors of the canonical repositories and they are not a source of published document content. Associated non-security repos, such as `wp-perfopt-guide`, may also be tracked here when useful, but they remain outside the four-document security series unless explicitly promoted.
 
 Use them only for repo-level tracking material that is helpful inside `ai-assisted-docs`, such as small internal changelog notes or process breadcrumbs.
 

--- a/reviews/README.md
+++ b/reviews/README.md
@@ -23,6 +23,7 @@ Use [docs/current-metrics.md](../docs/current-metrics.md) as the source of truth
 
 | File | Purpose |
 |---|---|
+| `SOP.md` | One-page standard operating procedure for the editorial multi-agent workflow |
 | `PROCESS-SUMMARY.md` | How the multi-model editorial process works in practice |
 | `REVISION-LOG.md` | Chronological log of all revision rounds, changes, and commits |
 | `wordpress-7.0-readiness-2026-03-15.md` | Version-reference readiness brief for the WordPress 7.0 and PHP 8.4 editorial sweep |
@@ -34,6 +35,7 @@ Use [docs/current-metrics.md](../docs/current-metrics.md) as the source of truth
 | `methodology/cross-document-audit-template.md` | Reusable template for future cross-document audits |
 | `methodology/example-revision-plan.md` | Example of a synthesized revision plan from a multi-model review |
 | `methodology/agent-review-board.md` | Pipeline vs. review board: comparing multi-agent documentation architectures |
+| `methodology/editorial-workflow-diagram.md` | Mermaid workflow diagram for the editorial multi-agent methodology |
 | `methodology/single-model-multi-agent.md` | How Claude's internal Opus/Sonnet/Haiku tier architecture works |
 | `methodology/multi-model-editorial-board.md` | Manual, semi-automated, and scripted approaches to orchestrating multi-model reviews |
 

--- a/reviews/SOP.md
+++ b/reviews/SOP.md
@@ -1,0 +1,157 @@
+# Editorial Multi-Agent SOP
+
+Standard operating procedure for editorial review and revision of the WordPress security document series.
+
+Current counts, phase status, and cross-repo metrics live in [docs/current-metrics.md](../docs/current-metrics.md). This SOP should reference that file rather than copying volatile totals.
+
+## Scope
+
+This SOP applies to the four canonical security documents:
+
+- Security Benchmark
+- Hardening Guide
+- Operations Runbook
+- Style Guide
+
+## Operating Modes
+
+### Default Mode
+
+Use the single-model, multi-agent workflow plus deterministic validators for:
+
+- normal edits
+- focused audits
+- small or medium revision rounds
+
+### Escalation Mode
+
+Use the multi-model editorial board for:
+
+- major cross-document revisions
+- release-quality milestones
+- periodic audit rounds
+- changes likely to expose cross-document drift
+
+## Procedure
+
+### Step 0 — Mechanical Preflight
+
+Run deterministic checks before model review:
+
+```bash
+bash tools/ci/review_preflight.sh
+```
+
+Preflight should catch or surface:
+
+- metrics drift
+- known WP-CLI regression patterns
+- glossary watchlist drift
+- workflow health issues
+
+If preflight fails, fix the defect or record it before broader review.
+
+### Step 1 — Independent Document Review
+
+Run specialized document review roles:
+
+- `@BenchmarkAgent`
+- `@HardeningGuideAgent`
+- `@RunbookAgent`
+- `@StyleGuideAgent`
+
+Each role reviews from its own domain perspective and produces structured findings. No approved-source edits happen at this stage.
+
+### Step 2 — Validation
+
+Run focused validation for mechanically checkable issues:
+
+- WP-CLI command validity
+- code block integrity
+- glossary coverage
+- reference and link checks
+
+### Step 3 — Cross-Document Audit
+
+Run `@AuditAgent` across the full four-document set to check:
+
+- classification symmetry
+- version and PHP floor consistency
+- code example agreement
+- cross-reference accuracy
+- glossary coverage
+
+Use [methodology/cross-document-audit-template.md](methodology/cross-document-audit-template.md) as the audit framework.
+
+### Step 4 — Synthesis
+
+Run `@SynthesisAgent` to:
+
+- merge findings
+- identify convergence and disagreement
+- verify claims against source files and the authority hierarchy
+- prioritize recommendations by severity and confidence
+
+### Step 5 — Human Editorial Decision
+
+The human editor reviews the synthesized findings and explicitly marks each one for acceptance, modification, or rejection.
+
+No change is applied without human approval.
+
+### Step 6 — Implementation
+
+Apply approved changes in the canonical repositories.
+
+Required follow-up:
+
+- update metrics if they changed
+- update changelog entries
+- preserve cross-document symmetry
+- regenerate and validate published artifacts when needed
+
+### Step 7 — Post-Implementation Audit
+
+Re-check:
+
+- cross-document consistency
+- command and code correctness
+- glossary coverage
+- cross-references
+- output generation and validation
+
+### Step 8 — Stateful Closeout
+
+Every synthesized finding must end in one final archival state:
+
+- `applied`
+- `rejected`
+- `stale`
+
+`Needs verification` is acceptable during active work, but not as the final closed-round status.
+
+## Authority Hierarchy
+
+When sources conflict, use this precedence:
+
+1. WordPress Developer Documentation
+2. WordPress core source and Code Reference
+3. WP-CLI documentation and source
+4. External standards for non-WordPress-specific topics
+
+Any deviation must be explicitly justified and labeled as conditional or environment-specific.
+
+## Guardrails
+
+- human editorial authority is final
+- no autonomous changes
+- no FUD
+- no speculative vulnerability claims
+- no unsupported WordPress, PHP, or WP-CLI assertions
+- no unresolved cross-document drift left unexamined
+
+## Related Process Docs
+
+- [PROCESS-SUMMARY.md](PROCESS-SUMMARY.md)
+- [methodology/single-model-multi-agent.md](methodology/single-model-multi-agent.md)
+- [methodology/multi-model-editorial-board.md](methodology/multi-model-editorial-board.md)
+- [methodology/editorial-workflow-diagram.md](methodology/editorial-workflow-diagram.md)

--- a/reviews/methodology/editorial-workflow-diagram.md
+++ b/reviews/methodology/editorial-workflow-diagram.md
@@ -1,0 +1,52 @@
+# Editorial Workflow Diagram
+
+Mermaid diagram for the WordPress security document series editorial methodology.
+
+This diagram summarizes the workflow described in:
+
+- [AGENTS.md](../../AGENTS.md)
+- [../PROCESS-SUMMARY.md](../PROCESS-SUMMARY.md)
+- [single-model-multi-agent.md](single-model-multi-agent.md)
+- [multi-model-editorial-board.md](multi-model-editorial-board.md)
+
+## Workflow
+
+```mermaid
+flowchart TD
+    A["Start editorial round"] --> B["Step 0: Mechanical preflight<br/>metrics / WP-CLI watchlist / glossary drift / workflow health"]
+
+    B --> C{"Preflight passes?"}
+    C -- "No" --> C1["Fix or record mechanical issues"] --> B
+    C -- "Yes" --> D{"Mode?"}
+
+    D -- "Default" --> E["Single-model multi-agent review"]
+    D -- "Escalation" --> F["Independent multi-model review<br/>Gemini / GPT / Claude"]
+
+    E --> E1["Parallel role reviews<br/>Benchmark / Hardening / Runbook / Style Guide"]
+    E1 --> E2["Validation pass<br/>commands / code blocks / glossary / references"]
+    E2 --> E3["Cross-document audit"]
+    E3 --> G["Synthesis"]
+
+    F --> F1["Collect independent review plans"]
+    F1 --> F2["Verify agreements and disagreements"]
+    F2 --> G["Synthesis"]
+
+    G --> H["Human editorial decision<br/>accept / modify / reject"]
+    H --> I{"Approved?"}
+
+    I -- "No" --> J["Archive as rejected or stale"]
+    I -- "Yes" --> K["Implement approved changes in canonical repos"]
+
+    K --> L["Update metrics / changelog / regenerate artifacts as needed"]
+    L --> M["Post-implementation audit"]
+    M --> N["Stateful closeout<br/>applied / rejected / stale"]
+    N --> O["Round complete"]
+    J --> O
+```
+
+## Reading Notes
+
+- **Default mode** is the normal operating path for routine editorial work.
+- **Escalation mode** adds independent external-model review when the revision scope or risk justifies it.
+- **Synthesis** never bypasses the human editor.
+- **Closeout** is not complete until every synthesized finding is archived as `applied`, `rejected`, or `stale`.

--- a/reviews/rounds/2026-06-14/runbook-skill-validation-older-vs-current.md
+++ b/reviews/rounds/2026-06-14/runbook-skill-validation-older-vs-current.md
@@ -1,0 +1,149 @@
+# Runbook Skill Validation — Older vs Current Canonical Runbook
+
+Date: 2026-06-14
+Method: Single-model skill validation using the installed `wordpress-runbook-ops` skill plus `wordpress-security-doc-editor` as the editorial audit lens
+Status: Closed
+
+## Purpose
+
+Test the revised runbook skill against:
+
+1. an older pre-hardening snapshot of the canonical WordPress Operations Runbook, and
+2. the current canonical runbook,
+
+to determine whether the skill usefully distinguishes legacy procedural weaknesses from later improvements.
+
+## Inputs
+
+### Skills tested
+
+- `/Users/danknauss/.codex/skills/wordpress-runbook-ops/SKILL.md`
+- `/Users/danknauss/.codex/skills/wordpress-security-doc-editor/SKILL.md`
+
+### Canonical/source references loaded
+
+- `/Users/danknauss/.codex/skills/wordpress-runbook-ops/references/canonical-sources.md`
+- `/Users/danknauss/.codex/skills/wordpress-security-doc-editor/references/canonical-sources.md`
+- `/Users/danknauss/.codex/scenarios/wordpress-runbook-ops/procedure-schema-completeness.md`
+- `/Users/danknauss/.codex/scenarios/wordpress-runbook-ops/command-validity.md`
+- `/Users/danknauss/.codex/scenarios/wordpress-security-doc-editor/cross-document-alignment.md`
+
+### Runbook targets
+
+- **Older snapshot:** `/tmp/WP-Operations-Runbook-4a18785.md`
+  - extracted from `wordpress-runbook-template` commit `4a18785`
+  - line count: `3237`
+- **Current canonical runbook:** `/Users/danknauss/Developer/GitHub/wordpress-runbook-template/WP-Operations-Runbook.md`
+  - audited in the patched working tree on branch `docs/runbook-skill-alignment`
+  - pre-patch `HEAD` at audit start: `46ec929` (`docs: add badges and AI disclosure`)
+  - line count after patch: `3394`
+
+## Audit checks performed
+
+1. **Strict procedure-schema signals**
+   - `### Procedure Metadata`
+   - `- Last Tested:`
+   - `- Review Cadence:`
+   - `- Last Drill Date:`
+   - `### Commands`
+   - `### Expected Output`
+   - `### Rollback`
+   - `### Verification`
+   - `### Escalate If`
+2. **WP-CLI command-path existence**
+   - `wp help <command>` style path validation, matching the source-driven check used in `tools/ci/check_wpcli_source_validity.py`
+3. **Known flag/usage regressions**
+   - `--post_status=scheduled`
+   - `wp term delete ... --default`
+   - `--field=` on commands that require `--fields=`
+   - related legacy WP-CLI usage drift
+4. **Mutation-safety coverage**
+   - destructive commands lacking nearby `# WARNING:` or `> **WARNING:**` markers
+5. **Plugin-dependent annotation style**
+   - current skill expectation: `# Plugin-dependent - uncomment the cache plugin(s) in use:`
+
+## Summary Result
+
+The revised runbook skill **successfully catches major weaknesses in the older snapshot** and **shows measurable improvement in the patched current canonical runbook**, but it also reveals that the current runbook still does **not** conform to the skill's stricter procedure-template format.
+
+In other words:
+
+- **command-path correctness** is strong in both versions,
+- **editorial/safety structure** improved significantly,
+- but **strict schema compliance remains incomplete even in the current document**.
+
+## Before / After Delta
+
+| Check | Older snapshot (`4a18785`) | Current canonical (patched working tree) | Delta |
+|---|---:|---:|---:|
+| WP-CLI command lines audited | 155 | 148 | -7 |
+| Unique WP-CLI command paths | 65 | 64 | -1 |
+| Invalid WP-CLI command paths | 0 | 0 | unchanged |
+| `### Procedure Metadata` sections | 0 | 0 | unchanged |
+| `### Commands` sections | 0 | 0 | unchanged |
+| `### Expected Output` sections | 0 | 0 | unchanged |
+| `### Rollback` sections | 0 | 0 | unchanged |
+| `### Verification` sections | 0 | 0 | unchanged |
+| `### Escalate If` sections | 0 | 0 | unchanged |
+| `Last Tested` metadata lines | 0 | 0 | unchanged |
+| `Review Cadence` metadata lines | 0 | 0 | unchanged |
+| `Last Drill Date` metadata lines | 0 | 0 | unchanged |
+| Destructive commands missing nearby warning markers | 52 | 10 | improved by 42 |
+| `# WARNING:` comment markers | 1 | 35 | improved by 34 |
+| `> **WARNING:**` blockquote warnings | 14 | 19 | improved by 5 |
+| Known flag/usage regressions found | 5 | 0 | improved by 5 |
+| Exact cache-plugin annotation string (`-`) | 0 | 6 | improved by 6 |
+| Cache-plugin annotation with em dash (`—`) | 6 | 0 | improved by 6 |
+
+## Verified Findings
+
+| Document | Location | Finding | Severity | Recommendation | Verification | Status |
+|---|---|---|---|---|---|---|
+| Older snapshot | global | The old runbook does not use the skill's required procedural schema headings or metadata fields. | High | Treat the old runbook as pre-schema legacy content rather than a valid example of current runbook structure. | Search for `### Procedure Metadata`, `### Commands`, `### Verification`, `### Rollback`, `### Escalate If`. | Verified |
+| Older snapshot | global | Command-path existence is mostly sound: the old runbook is not dominated by fabricated WP-CLI subcommands. | Medium | Preserve this distinction in future audits: command-path existence alone is not enough. | `wp help <command>` path audit found `0` invalid command paths across `155` command lines. | Verified |
+| Older snapshot | lines `1868`, `1872`, `1909`, `2167`, `2176` | The older runbook contains known legacy WP-CLI flag/usage regressions (`--post_status=scheduled`, `wp term delete ... --default=1`, singular `--field=` usage). | High | Keep these patterns in the regression watchlist and treat them as true positives for the skill. | Exact line scan against the extracted snapshot. | Verified |
+| Older snapshot | 52 destructive-command locations | Mutation safety is substantially weaker in the old snapshot. | High | Use the newer runbook as the minimum safety baseline; require warning coverage or explicit rationale. | Count destructive commands without a warning marker in the preceding window. | Verified |
+| Current canonical | global | The current runbook still does not match the skill's strict procedure-schema headings/metadata model, despite major safety improvements. | High | Decide whether to (a) refactor the canonical runbook toward the skill's full template, or (b) relax the skill so it better matches the canonical document architecture. | Same structural heading/metadata scan as above returns zero required schema headings. | Verified |
+| Current canonical | global | The residual mutation-safety gap dropped from 29 to 10 heuristic hits after the patch. Most remaining hits are read-only `wp db query` checks, a dry-run `wp search-replace`, and one already-warning-adjacent `wp plugin deactivate --all` case that the narrow scan window still counts. | Medium | Triage the remaining 10 cases into: benign read-only checks, widen the audit heuristic, or add explicit read-only labels where helpful. | Same warning-window scan used for the older snapshot. | Verified |
+| Current canonical | global | The current runbook no longer contains the singular `--field=` regressions or the em-dash cache-plugin annotation variant flagged in the first pass. | Low | Keep these exact strings in regression coverage so they stay fixed. | Post-patch line scan and regex count show `0` residual matches for those patterns. | Verified |
+
+## Interpretation
+
+### What the test proves
+
+The runbook skill is useful as an **editorial review tool** because it:
+
+- distinguishes **real command-path problems** from **editorial/safety problems**
+- catches known WP-CLI usage regressions in the older runbook
+- surfaces a measurable improvement in warning coverage and operational caution
+- correctly identifies that the current canonical runbook is **better**, but still **not fully aligned** with the stricter skill template
+
+### What the test does not prove
+
+This validation does **not** prove that:
+
+- every remaining WP-CLI flag in the current runbook is wrong
+- every destructive command without a nearby warning must necessarily gain one
+- the current canonical runbook should be rewritten wholesale into the stricter skill template without editorial review
+
+Some findings are best understood as a **fit gap between the skill and the canonical document architecture**, not just a document defect.
+
+## Recommendations
+
+1. **Keep the revised runbook skill.** It clearly improves detection of legacy runbook weaknesses.
+2. **Keep the current patch set.** It materially improved the canonical runbook against the skill's own audit lens without forcing a wholesale rewrite.
+3. **Do a fit-alignment pass** between the skill and the canonical runbook:
+   - either refactor the runbook closer to the skill schema, or
+   - relax the skill where the canonical document structure is intentionally broader.
+4. **Promote the regression cases to reusable tests** if not already covered:
+   - `--post_status=scheduled`
+   - `wp term delete ... --default`
+   - singular `--field=` patterns in audited command contexts
+5. **Triage the remaining 10 current warning gaps** rather than assuming they are all equally severe.
+6. **Decide whether read-only `wp db query` checks should be explicitly labeled** so the skill and heuristic can distinguish them from mutating SQL workflows.
+
+## Final Conclusion
+
+This was a **successful skill validation**.
+
+The new `wordpress-runbook-ops` skill does what it should against older WordPress runbook material: it catches structural looseness, weaker mutation safety, and known WP-CLI usage drift. Against the patched current canonical runbook, it shows strong improvement on warning coverage and residual WP-CLI usage issues while still revealing one important unresolved issue: the skill's preferred procedure-template structure is stricter than the structure used by the current canonical runbook itself.

--- a/reviews/wordpress-7.0-release-notes-impact-2026-06-14.md
+++ b/reviews/wordpress-7.0-release-notes-impact-2026-06-14.md
@@ -4,8 +4,8 @@ This note isolates **release-notes-era changes** in WordPress `7.0` that are rel
 
 It supplements, but does not replace:
 
-- `/Users/danknauss/Developer/GitHub/ai-assisted-docs/reviews/wordpress-7.0-postrelease-research-2026-06-14.md`
-- `/Users/danknauss/Developer/GitHub/ai-assisted-docs/reviews/wordpress-7.0-cross-repo-edit-plan-2026-06-14.md`
+- `reviews/wordpress-7.0-postrelease-research-2026-06-14.md`
+- `reviews/wordpress-7.0-cross-repo-edit-plan-2026-06-14.md`
 
 This is a **research artifact only**. No canonical source documents are changed here.
 

--- a/tools/ci/review_preflight.sh
+++ b/tools/ci/review_preflight.sh
@@ -37,6 +37,10 @@ echo "-- Glossary coverage watchlist --"
 bash "${ROOT_DIR}/tools/ci/check_glossary_watchlist.sh"
 echo
 
+echo "-- Skill bundle integrity --"
+python3 "${ROOT_DIR}/tools/ci/validate_skill_bundles.py"
+echo
+
 echo "-- Workflow lint --"
 if command -v actionlint >/dev/null 2>&1; then
   (

--- a/tools/ci/validate_skill_bundles.py
+++ b/tools/ci/validate_skill_bundles.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate local WordPress skill bundles and their referenced resources."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+STD_REQUIRED_FILES = (
+    "SKILL.md",
+    "agents/claude.yaml",
+    "agents/openai.yaml",
+    "references/canonical-sources.md",
+)
+
+RELATIVE_REF_RE = re.compile(
+    r"""
+    (?:
+        `(?P<code>(?:\.\./)+scenarios/[^`\s]+|references/[^`\s]+|agents/[^`\s]+|scripts/[^`\s]+|assets/[^`\s]+)` |
+        \]\((?P<link>(?:\.\./)+scenarios/[^)\s]+|references/[^)\s]+|agents/[^)\s]+|scripts/[^)\s]+|assets/[^)\s]+)\)
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate wp-docs-skills bundle structure and relative references."
+    )
+    parser.add_argument(
+        "--skills-root",
+        default=None,
+        help="Root directory containing skill bundle directories. Defaults to <repo>/wp-docs-skills.",
+    )
+    return parser.parse_args()
+
+
+def resolve_skills_root(arg_value: str | None) -> Path:
+    if arg_value:
+        return Path(arg_value).expanduser().resolve()
+    return Path(__file__).resolve().parents[2] / "wp-docs-skills"
+
+
+def collect_relative_refs(skill_md: Path) -> list[str]:
+    text = skill_md.read_text(encoding="utf-8")
+    refs: list[str] = []
+    for match in RELATIVE_REF_RE.finditer(text):
+        ref = match.group("code") or match.group("link")
+        if ref:
+            refs.append(ref.rstrip(".,:;"))
+    return sorted(set(refs))
+
+
+def main() -> int:
+    args = parse_args()
+    skills_root = resolve_skills_root(args.skills_root)
+
+    if not skills_root.is_dir():
+        print(f"ERROR: skills root not found: {skills_root}", file=sys.stderr)
+        return 1
+
+    skill_dirs = sorted(
+        path for path in skills_root.iterdir() if path.is_dir() and (path / "SKILL.md").exists()
+    )
+    if not skill_dirs:
+        print(f"ERROR: no skill bundles found under {skills_root}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+
+    for skill_dir in skill_dirs:
+        skill_name = skill_dir.name
+        print(f"Checking skill bundle: {skill_name}")
+
+        for relpath in STD_REQUIRED_FILES:
+            candidate = skill_dir / relpath
+            if not candidate.exists():
+                errors.append(f"{skill_name}: missing required bundle file {relpath}")
+
+        skill_md = skill_dir / "SKILL.md"
+        for ref in collect_relative_refs(skill_md):
+            resolved = (skill_dir / ref).resolve()
+            if not resolved.exists():
+                errors.append(f"{skill_name}: referenced path missing: {ref}")
+
+    if errors:
+        print("\nSkill bundle validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("\nSkill bundle validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sync_wp_docs_skills.sh
+++ b/tools/sync_wp_docs_skills.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILLS_ROOT="${ROOT_DIR}/wp-docs-skills"
+SCENARIOS_ROOT="${ROOT_DIR}/scenarios"
+DEST_ROOTS=(
+  "${HOME}/.codex/skills"
+  "${HOME}/.agents/skills"
+)
+
+python3 "${ROOT_DIR}/tools/ci/validate_skill_bundles.py"
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "ERROR: rsync is required for skill sync/install." >&2
+  exit 1
+fi
+
+for dest_root in "${DEST_ROOTS[@]}"; do
+  home_root="$(dirname "${dest_root}")"
+  mkdir -p "${dest_root}"
+  echo "== Syncing WordPress doc skills into ${dest_root} =="
+
+  for skill_dir in "${SKILLS_ROOT}"/*; do
+    [[ -d "${skill_dir}" ]] || continue
+    skill_name="$(basename "${skill_dir}")"
+    [[ -f "${skill_dir}/SKILL.md" ]] || continue
+    rsync -a --delete "${skill_dir}/" "${dest_root}/${skill_name}/"
+    if diff -qr "${skill_dir}" "${dest_root}/${skill_name}" >/dev/null; then
+      echo "OK   ${skill_name}"
+    else
+      echo "ERROR: post-sync verification failed for ${dest_root}/${skill_name}" >&2
+      diff -qr "${skill_dir}" "${dest_root}/${skill_name}" || true
+      exit 1
+    fi
+  done
+
+  mkdir -p "${home_root}/scenarios"
+  echo "== Syncing scenario mirror into ${home_root}/scenarios =="
+  rsync -a --delete "${SCENARIOS_ROOT}/" "${home_root}/scenarios/"
+  if diff -qr "${SCENARIOS_ROOT}" "${home_root}/scenarios" >/dev/null; then
+    echo "OK   scenarios"
+  else
+    echo "ERROR: post-sync scenario verification failed for ${home_root}/scenarios" >&2
+    diff -qr "${SCENARIOS_ROOT}" "${home_root}/scenarios" || true
+    exit 1
+  fi
+done
+
+echo
+echo "WordPress doc skill sync complete."

--- a/wp-docs-skills/README.md
+++ b/wp-docs-skills/README.md
@@ -30,6 +30,28 @@ Each skill bundle contains:
 
 ## Usage
 
+### Install / Sync Into Local Agent Homes
+
+To install or refresh these WordPress documentation skills into local Codex and Claude-compatible skill directories, run:
+
+```bash
+bash tools/sync_wp_docs_skills.sh
+```
+
+This syncs the full bundle for each skill — including `agents/` and `references/` resources — into:
+
+- `~/.codex/skills/`
+- `~/.agents/skills/`
+
+It also mirrors the repository's `scenarios/` tree into:
+
+- `~/.codex/scenarios/`
+- `~/.agents/scenarios/`
+
+That mirror keeps the skills' existing relative behavioral-scenario references valid after installation.
+
+The sync script validates bundle integrity before copying and verifies the copied result after installation.
+
 ### Claude Code
 
 Reference the skill in a Claude Code session by reading the `SKILL.md` file or including it as project context.


### PR DESCRIPTION
Richer editorial branch: adds the editorial methodology SOP + workflow diagram, performance-series tracking, hardened WordPress skill-bundle installs, and a runbook skill-validation artifact (plus the shared docs CI refactor).

:warning: Does NOT auto-merge (13 files changed). Overlaps docs/current-metrics.md, CHANGELOG.md and the CI workflow files — some of which just landed via #14 (state-refresh). Needs a rebase onto main + conflict resolution before merging. Opening as a tracked PR; do not merge as-is.